### PR TITLE
Add the ability to run a profile for a given duration instead of a number of iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,9 @@ Key value workload with a million operations across 5k partitions, 50:50 read:wr
 
 Time series workload, using TWCS:
 
-    bin/tlp-stress run KeyValue -i 10M --compaction "{'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'DAYS'}"
+    bin/tlp-stress run BasicTimeSeries -i 10M --compaction "{'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'DAYS'}"
+
+Time series workload with a run lasting 1h and 30mins:
+
+    bin/tlp-stress run BasicTimeSeries -d "1h 30m"
 

--- a/manual/MANUAL.adoc
+++ b/manual/MANUAL.adoc
@@ -104,6 +104,18 @@ Whenever possible we try to use human friendly numbers.  Typing out `-n 10000000
 
 |===
 
+=== Running a stress test for a given duration instead of a number of operations
+
+You might need to run a stress test for a given duration instead of providing a number of operations, especially in case of multithreaded stress runs. This is done by providing the duration in a human readable format with the `-d` argument. The minimum duration is 1 minute.
+For example, running a test for 1 hours and 30 minutes will be done as follows:
+```
+tlp-stress run KeyValue -d "1h 30m"
+```
+
+To run a test for 1 days, 3 hours and 15 minutes (why not?), run tlp-stress as follows:
+```
+tlp-stress run KeyValue -d "1d 3h 15m"
+```
 
 ==== Partition Keys
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
@@ -11,10 +11,8 @@ data class StressContext(val session: Session,
                          val mainArguments: Run,
                          val thread: Int,
                          val metrics: Metrics,
-                         val semaphore: Semaphore,
                          val permits: Int,
                          val registry: Registry,
-                         val rateLimiter: RateLimiter?,
-                         val consistencyLevel: ConsistencyLevel)
+                         val rateLimiter: RateLimiter?)
 
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -4,11 +4,13 @@ import com.beust.jcommander.DynamicParameter
 import com.beust.jcommander.Parameter
 import com.beust.jcommander.Parameters
 import com.datastax.driver.core.*
+import com.google.common.base.Preconditions
 import com.google.common.util.concurrent.RateLimiter
 import com.thelastpickle.tlpstress.*
 import com.thelastpickle.tlpstress.Metrics
 import com.thelastpickle.tlpstress.converters.ConsistencyLevelConverter
 import com.thelastpickle.tlpstress.converters.HumanReadableConverter
+import com.thelastpickle.tlpstress.converters.HumanReadableTimeConverter
 import com.thelastpickle.tlpstress.generators.Registry
 import java.util.concurrent.Semaphore
 
@@ -60,7 +62,11 @@ class Run : IStressCommand {
     var threads = 1
 
     @Parameter(names = ["--iterations", "-i", "-n"], description = "Number of operations to run.", converter = HumanReadableConverter::class)
-    var iterations : Long = 1000
+    var iterations : Long = 0
+    val DEFAULT_ITERATIONS : Long = 1000000
+
+    @Parameter(names = ["--duration", "-d"], description = "Duration of the stress test.", converter = HumanReadableTimeConverter::class)
+    var duration : Int = 0
 
     @Parameter(names = ["-h", "--help"], description = "Show this help", help = true)
     var help = false
@@ -82,6 +88,10 @@ class Run : IStressCommand {
 
     
     override fun execute() {
+
+        Preconditions.checkArgument(!(duration > 0 && iterations > 0L), "Duration and iterations shouldn't be both set at the same time. Please pick just one.")
+        iterations = if (duration == 0 && iterations == 0L) DEFAULT_ITERATIONS else iterations // apply the default if the number of iterations wasn't set
+
 
         // we're going to build one session per thread for now
         val cluster = Cluster.builder()
@@ -170,12 +180,11 @@ class Run : IStressCommand {
         val metrics = Metrics()
 
         val permits = concurrency
-        var sem = Semaphore(permits.toInt())
 
         // run the prepare for each
         val runners = IntRange(0, threads - 1).map {
             println("Connecting")
-            val context = StressContext(session, this, it, metrics, sem, permits.toInt(), fieldRegistry, rateLimiter, consistencyLevel)
+            val context = StressContext(session, this, it, metrics, permits.toInt(), fieldRegistry, rateLimiter)
             ProfileRunner.create(context, plugin.instance)
         }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverter.kt
@@ -1,0 +1,40 @@
+package com.thelastpickle.tlpstress.converters
+
+import com.beust.jcommander.IStringConverter
+import org.joda.time.Period
+import org.joda.time.format.PeriodFormatterBuilder
+import org.joda.time.format.PeriodFormatter
+
+
+
+class HumanReadableTimeConverter : IStringConverter<Int> {
+    override fun convert(value: String?): Int {
+        val daysFormatter = PeriodFormatterBuilder()
+                .appendDays().appendSuffix("d").appendSeparatorIfFieldsAfter(" ")
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+        val hoursFormatter = PeriodFormatterBuilder()
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+        val minutesFormatter = PeriodFormatterBuilder()
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+
+        var duration = Period()
+
+        if (value!!.contains('d')) {
+            duration = daysFormatter.parsePeriod(value)
+        } else if (value!!.contains('h')) {
+            duration = hoursFormatter.parsePeriod(value)
+        } else {
+            duration = minutesFormatter.parsePeriod(value)
+        }
+
+        return duration.toStandardMinutes().minutes
+    }
+}

--- a/src/test/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverterTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverterTest.kt
@@ -1,0 +1,36 @@
+package com.thelastpickle.tlpstress.converters
+
+import com.datastax.driver.core.ConsistencyLevel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+import kotlin.test.assertFailsWith
+
+internal class HumanReadableTimeConverterTest {
+
+    lateinit var converter: HumanReadableTimeConverter
+
+    @BeforeEach
+    fun setUp() {
+        converter = HumanReadableTimeConverter()
+    }
+
+    @Test
+    fun convert() {
+        assertThat(converter.convert("1h")).isEqualTo(60)
+        assertThat(converter.convert("1d 1h")).isEqualTo(1500)
+        assertThat(converter.convert("1d 2h 10m")).isEqualTo(1570)
+        assertThat(converter.convert("3h")).isEqualTo(180)
+        assertThat(converter.convert("1h 5m")).isEqualTo(65)
+        assertThat(converter.convert("15m")).isEqualTo(15)
+    }
+
+    @Test
+    fun convertAndFail() {
+        assertFailsWith<java.lang.IllegalArgumentException> {val cl = converter.convert("BLAh")}
+        assertFailsWith<java.lang.IllegalArgumentException> {val cl = converter.convert("1m 1h")}
+    }
+}


### PR DESCRIPTION
The duration is passed in human readable format (example : "1d 5h 10m") and will be converted to minutes.
If the duration is set to 0, the number of iterations will be used instead.