### PR TITLE
Add the possibility to suffix the table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,9 @@ Key value workload with a million operations across 5k partitions, 50:50 read:wr
 
 Time series workload, using TWCS:
 
-    bin/tlp-stress run KeyValue -i 10M --compaction "{'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'DAYS'}"
+    bin/tlp-stress run BasicTimeSeries -i 10M --compaction "{'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'DAYS'}"
+
+Time series workload with a run lasting 1h and 30mins:
+
+    bin/tlp-stress run BasicTimeSeries -d 1h 30m
 

--- a/manual/MANUAL.adoc
+++ b/manual/MANUAL.adoc
@@ -104,6 +104,18 @@ Whenever possible we try to use human friendly numbers.  Typing out `-n 10000000
 
 |===
 
+=== Running a stress test for a given duration instead of a number of operations
+
+You might need to run a stress test for a given duration instead of providing a number of operations, especially in case of multithreaded stress runs. This is done by providing the duration in a human readable format with the `-d` argument. The minimum duration is 1 minute.
+For example, running a test for 1 hours and 30 minutes will be done as follows:
+```
+tlp-stress run KeyValue -d 1h 30m
+```
+
+To run a test for 1 days, 3 hours and 15 minutes (why not?), run tlp-stress as follows:
+```
+tlp-stress run KeyValue -d 1d 3h 15m
+```
 
 ==== Partition Keys
 

--- a/manual/MANUAL.adoc
+++ b/manual/MANUAL.adoc
@@ -159,6 +159,16 @@ There are other generators available, such as names, gaussian numbers,
 and cities. Not every generator applies to every type. It’s up to the
 workload to specify which fields can be used this way.
 
+==== Table name suffix
+
+In order to start concurrent runners on separate tables but using the same profile, you can add a suffix to the table name by using the optional "--table-suffix" command line argument. It will add the provided value to the stress table name.
+Running the following:
+```
+tlp-stress run KeyValue --table-suffix "_test1"
+```
+
+will generate a table called `tlp_stress.sensor_data_test1` instead of the default `tlp_stress.sensor_data`.
+
 == Developer Docs
 
 === Building the documentation

--- a/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
@@ -179,7 +179,7 @@ class ProfileRunner(val context: StressContext,
     }
 
     fun prepare() {
-        profile.prepare(context.session)
+        profile.prepare(context.session, context.mainArguments.tableSuffix)
         val prefix = context.mainArguments.id + "." + context.thread + "."
         val sequenceGenerator = PartitionKeyGenerator.sequence(prefix)
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
@@ -11,11 +11,8 @@ data class StressContext(val session: Session,
                          val mainArguments: Run,
                          val thread: Int,
                          val metrics: Metrics,
-                         val semaphore: Semaphore,
                          val permits: Int,
                          val registry: Registry,
-                         val rateLimiter: RateLimiter?,
-                         val consistencyLevel: ConsistencyLevel,
-                         val duration: Int)
+                         val rateLimiter: RateLimiter?)
 
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
@@ -15,6 +15,7 @@ data class StressContext(val session: Session,
                          val permits: Int,
                          val registry: Registry,
                          val rateLimiter: RateLimiter?,
-                         val consistencyLevel: ConsistencyLevel)
+                         val consistencyLevel: ConsistencyLevel,
+                         val duration: Int)
 
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Info.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Info.kt
@@ -16,7 +16,7 @@ class Info : IStressCommand {
         val plugin = Plugin.getPlugins().get(profile)!!
 
 
-        for(cql in plugin.instance.schema()) {
+        for(cql in plugin.instance.schema("")) {
             println(cql)
         }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -9,6 +9,7 @@ import com.thelastpickle.tlpstress.*
 import com.thelastpickle.tlpstress.Metrics
 import com.thelastpickle.tlpstress.converters.ConsistencyLevelConverter
 import com.thelastpickle.tlpstress.converters.HumanReadableConverter
+import com.thelastpickle.tlpstress.converters.HumanReadableTimeConverter
 import com.thelastpickle.tlpstress.generators.Registry
 import java.util.concurrent.Semaphore
 
@@ -61,6 +62,9 @@ class Run : IStressCommand {
 
     @Parameter(names = ["--iterations", "-i", "-n"], description = "Number of operations to run.", converter = HumanReadableConverter::class)
     var iterations : Long = 1000
+
+    @Parameter(names = ["--duration", "-d"], description = "Duration of the stress test.", converter = HumanReadableTimeConverter::class)
+    var duration : Int = 0
 
     @Parameter(names = ["-h", "--help"], description = "Show this help", help = true)
     var help = false
@@ -175,7 +179,7 @@ class Run : IStressCommand {
         // run the prepare for each
         val runners = IntRange(0, threads - 1).map {
             println("Connecting")
-            val context = StressContext(session, this, it, metrics, sem, permits.toInt(), fieldRegistry, rateLimiter, consistencyLevel)
+            val context = StressContext(session, this, it, metrics, sem, permits.toInt(), fieldRegistry, rateLimiter, consistencyLevel, duration)
             ProfileRunner.create(context, plugin.instance)
         }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -174,12 +174,11 @@ class Run : IStressCommand {
         val metrics = Metrics()
 
         val permits = concurrency
-        var sem = Semaphore(permits.toInt())
 
         // run the prepare for each
         val runners = IntRange(0, threads - 1).map {
             println("Connecting")
-            val context = StressContext(session, this, it, metrics, sem, permits.toInt(), fieldRegistry, rateLimiter, consistencyLevel, duration)
+            val context = StressContext(session, this, it, metrics, permits.toInt(), fieldRegistry, rateLimiter)
             ProfileRunner.create(context, plugin.instance)
         }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverter.kt
@@ -1,0 +1,40 @@
+package com.thelastpickle.tlpstress.converters
+
+import com.beust.jcommander.IStringConverter
+import org.joda.time.Period
+import org.joda.time.format.PeriodFormatterBuilder
+import org.joda.time.format.PeriodFormatter
+
+
+
+class HumanReadableTimeConverter : IStringConverter<Int> {
+    override fun convert(value: String?): Int {
+        val daysFormatter = PeriodFormatterBuilder()
+                .appendDays().appendSuffix("d").appendSeparatorIfFieldsAfter(" ")
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+        val hoursFormatter = PeriodFormatterBuilder()
+                .appendHours().appendSuffix("h").appendSeparatorIfFieldsAfter(" ")
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+        val minutesFormatter = PeriodFormatterBuilder()
+                .appendMinutes().appendSuffix("m")
+                .toFormatter();
+
+
+        var duration = Period()
+
+        if (value!!.contains('d')) {
+            duration = daysFormatter.parsePeriod(value)
+        } else if (value!!.contains('h')) {
+            duration = hoursFormatter.parsePeriod(value)
+        } else {
+            duration = minutesFormatter.parsePeriod(value)
+        }
+
+        return duration.toStandardMinutes().minutes
+    }
+}

--- a/src/main/kotlin/com/thelastpickle/tlpstress/converters/ValidTableNameConverter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/converters/ValidTableNameConverter.kt
@@ -1,0 +1,15 @@
+package com.thelastpickle.tlpstress.converters
+
+import com.beust.jcommander.IStringConverter
+import org.joda.time.Period
+import org.joda.time.format.PeriodFormatterBuilder
+import org.joda.time.format.PeriodFormatter
+
+
+
+class ValidTableNameConverter : IStringConverter<String> {
+    override fun convert(value: String?): String {
+        val re = Regex("[^a-z0-9_]")
+        return re.replace(value!!, "_")
+    }
+}

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/IStressProfile.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/IStressProfile.kt
@@ -32,7 +32,7 @@ interface IStressProfile {
      * the class should track all prepared statements internally
      * and pass them on to the Runner
      */
-    fun prepare(session: Session)
+    fun prepare(session: Session, tableSuffix: String)
     /**
      * returns a bunch of DDL statements
      * this can be create table, index, materialized view, etc
@@ -45,7 +45,7 @@ interface IStressProfile {
      * there are plenty of use cases where you would want a specific
      * compaction strategy most of the time (like a time series, or a cache)
      */
-    fun schema(): List<String>
+    fun schema(tableSuffix: String): List<String>
 
     /**
      * returns an instance of the stress runner for this particular class

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/basictimeseries/BasicTimeSeries.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/basictimeseries/BasicTimeSeries.kt
@@ -27,8 +27,8 @@ class BasicTimeSeries : IStressProfile {
 
     data class PrimaryKey(val first: String, val timestamp: UUID)
 
-    override fun schema(): List<String> {
-        val query = """CREATE TABLE IF NOT EXISTS sensor_data (
+    override fun schema(tableSuffix: String): List<String> {
+        val query = """CREATE TABLE IF NOT EXISTS sensor_data$tableSuffix (
                             sensor_id text,
                             timestamp timeuuid,
                             data text,
@@ -43,10 +43,10 @@ class BasicTimeSeries : IStressProfile {
     lateinit var getRow: PreparedStatement
     lateinit var getPartitionHead: PreparedStatement
 
-    override fun prepare(session: Session) {
-        prepared = session.prepare("INSERT INTO sensor_data (sensor_id, timestamp, data) VALUES (?, ?, ?)")
-        getRow = session.prepare("SELECT * from sensor_data WHERE sensor_id = ? AND timestamp = ? ")
-        getPartitionHead = session.prepare("SELECT * from sensor_data WHERE sensor_id = ? LIMIT ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        prepared = session.prepare("INSERT INTO sensor_data$tableSuffix (sensor_id, timestamp, data) VALUES (?, ?, ?)")
+        getRow = session.prepare("SELECT * from sensor_data$tableSuffix WHERE sensor_id = ? AND timestamp = ? ")
+        getPartitionHead = session.prepare("SELECT * from sensor_data$tableSuffix WHERE sensor_id = ? LIMIT ?")
     }
 
     /**

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/counterswide/CountersWide.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/counterswide/CountersWide.kt
@@ -16,14 +16,14 @@ class CountersWide : IStressProfile {
     lateinit var selectOne: PreparedStatement
     lateinit var selectAll: PreparedStatement
 
-    override fun prepare(session: Session) {
-        increment = session.prepare("UPDATE counter_wide SET value = value + 1 WHERE key = ? and cluster = ?")
-        selectOne = session.prepare("SELECT * from counter_wide WHERE key = ? AND cluster = ?")
-        selectAll = session.prepare("SELECT * from counter_wide WHERE key = ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        increment = session.prepare("UPDATE counter_wide$tableSuffix SET value = value + 1 WHERE key = ? and cluster = ?")
+        selectOne = session.prepare("SELECT * from counter_wide$tableSuffix WHERE key = ? AND cluster = ?")
+        selectAll = session.prepare("SELECT * from counter_wide$tableSuffix WHERE key = ?")
     }
 
-    override fun schema(): List<String> {
-        return listOf("""CREATE TABLE IF NOT EXISTS counter_wide (
+    override fun schema(tableSuffix: String): List<String> {
+        return listOf("""CREATE TABLE IF NOT EXISTS counter_wide$tableSuffix (
             | key text,
             | cluster bigint,
             | value counter,

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/keyvalue/KeyValue.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/keyvalue/KeyValue.kt
@@ -25,13 +25,13 @@ class KeyValue : IStressProfile {
 
     data class PrimaryKey(val first: String)
 
-    override fun prepare(session: Session) {
-        insert = session.prepare("INSERT INTO keyvalue (key, value) VALUES (?, ?)")
-        select = session.prepare("SELECT * from keyvalue WHERE key = ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        insert = session.prepare("INSERT INTO keyvalue$tableSuffix (key, value) VALUES (?, ?)")
+        select = session.prepare("SELECT * from keyvalue$tableSuffix WHERE key = ?")
     }
 
-    override fun schema(): List<String> {
-        val table = """CREATE TABLE IF NOT EXISTS keyvalue (
+    override fun schema(tableSuffix: String): List<String> {
+        val table = """CREATE TABLE IF NOT EXISTS keyvalue$tableSuffix (
                         key text PRIMARY KEY,
                         value text
                         )""".trimIndent()

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/lwt/LWT.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/lwt/LWT.kt
@@ -15,14 +15,14 @@ class LWT : IStressProfile {
     lateinit var update: PreparedStatement
     lateinit var select: PreparedStatement
 
-    override fun schema(): List<String> {
-        return arrayListOf("""CREATE TABLE IF NOT EXISTS lwt (id text primary key, value int) """)
+    override fun schema(tableSuffix: String): List<String> {
+        return arrayListOf("""CREATE TABLE IF NOT EXISTS lwt$tableSuffix (id text primary key, value int) """)
     }
 
-    override fun prepare(session: Session) {
-        insert = session.prepare("INSERT INTO lwt (id, value) VALUES (?, ?) IF NOT EXISTS")
-        update = session.prepare("UPDATE lwt SET value = ? WHERE id = ? IF value = ?")
-        select = session.prepare("SELECT * from lwt WHERE id = ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        insert = session.prepare("INSERT INTO lwt$tableSuffix (id, value) VALUES (?, ?) IF NOT EXISTS")
+        update = session.prepare("UPDATE lwt$tableSuffix SET value = ? WHERE id = ? IF value = ?")
+        select = session.prepare("SELECT * from lwt$tableSuffix WHERE id = ?")
     }
 
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/maps/Maps.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/maps/Maps.kt
@@ -19,13 +19,13 @@ class Maps : IStressProfile {
 
     data class PrimaryKey(val field: String)
 
-    override fun prepare(session: Session) {
-        insert = session.prepare("UPDATE map_stress SET data[?] = ? WHERE id = ?")
-        select = session.prepare("SELECT * from map_stress WHERE id = ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        insert = session.prepare("UPDATE map_stress$tableSuffix SET data[?] = ? WHERE id = ?")
+        select = session.prepare("SELECT * from map_stress$tableSuffix WHERE id = ?")
     }
 
-    override fun schema(): List<String> {
-        val query = """ CREATE TABLE IF NOT EXISTS map_stress (id text, data map<text, text>, primary key (id)) """
+    override fun schema(tableSuffix: String): List<String> {
+        val query = """ CREATE TABLE IF NOT EXISTS map_stress$tableSuffix (id text, data map<text, text>, primary key (id)) """
         return listOf(query)
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/materializedviews/MaterializedViews.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/materializedviews/MaterializedViews.kt
@@ -15,25 +15,25 @@ import java.util.concurrent.ThreadLocalRandom
 
 class MaterializedViews : IStressProfile {
 
-    override fun prepare(session: Session) {
-        insert = session.prepare("INSERT INTO person (name, age, city) values (?, ?, ?)")
-        select_base = session.prepare("SELECT * FROM person WHERE name = ?")
-        select_by_age = session.prepare("SELECT * FROM person_by_age WHERE age = ?")
-        select_by_city = session.prepare("SELECT * FROM person_by_city WHERE city = ?")
+    override fun prepare(session: Session, tableSuffix: String) {
+        insert = session.prepare("INSERT INTO person$tableSuffix (name, age, city) values (?, ?, ?)")
+        select_base = session.prepare("SELECT * FROM person$tableSuffix WHERE name = ?")
+        select_by_age = session.prepare("SELECT * FROM person_by_age$tableSuffix WHERE age = ?")
+        select_by_city = session.prepare("SELECT * FROM person_by_city$tableSuffix WHERE city = ?")
 
 
     }
 
-    override fun schema(): List<String> = listOf("""CREATE TABLE IF NOT EXISTS person
+    override fun schema(tableSuffix: String): List<String> = listOf("""CREATE TABLE IF NOT EXISTS person$tableSuffix
                         | (name text, age int, city text, primary key(name))""".trimMargin(),
 
-                        """CREATE MATERIALIZED VIEW IF NOT EXISTS person_by_age AS
-                            |SELECT age, name, city FROM person
+                        """CREATE MATERIALIZED VIEW IF NOT EXISTS person_by_age$tableSuffix AS
+                            |SELECT age, name, city FROM person$tableSuffix
                             |WHERE age IS NOT NULL AND name IS NOT NULL
                             |PRIMARY KEY (age, name)""".trimMargin(),
 
-                        """CREATE MATERIALIZED VIEW IF NOT EXISTS person_by_city AS
-                            |SELECT city, name, age FROM person
+                        """CREATE MATERIALIZED VIEW IF NOT EXISTS person_by_city$tableSuffix AS
+                            |SELECT city, name, age FROM person$tableSuffix
                             |WHERE city IS NOT NULL AND name IS NOT NULL
                             |PRIMARY KEY (city, name) """.trimMargin())
 

--- a/src/test/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverterTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpstress/converters/HumanReadableTimeConverterTest.kt
@@ -1,0 +1,36 @@
+package com.thelastpickle.tlpstress.converters
+
+import com.datastax.driver.core.ConsistencyLevel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+import kotlin.test.assertFailsWith
+
+internal class HumanReadableTimeConverterTest {
+
+    lateinit var converter: HumanReadableTimeConverter
+
+    @BeforeEach
+    fun setUp() {
+        converter = HumanReadableTimeConverter()
+    }
+
+    @Test
+    fun convert() {
+        assertThat(converter.convert("1h")).isEqualTo(60)
+        assertThat(converter.convert("1d 1h")).isEqualTo(1500)
+        assertThat(converter.convert("1d 2h 10m")).isEqualTo(1570)
+        assertThat(converter.convert("3h")).isEqualTo(180)
+        assertThat(converter.convert("1h 5m")).isEqualTo(65)
+        assertThat(converter.convert("15m")).isEqualTo(15)
+    }
+
+    @Test
+    fun convertAndFail() {
+        assertFailsWith<java.lang.IllegalArgumentException> {val cl = converter.convert("BLAh")}
+        assertFailsWith<java.lang.IllegalArgumentException> {val cl = converter.convert("1m 1h")}
+    }
+}

--- a/src/test/kotlin/com/thelastpickle/tlpstress/converters/ValidTableNameConverterTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpstress/converters/ValidTableNameConverterTest.kt
@@ -1,0 +1,26 @@
+package com.thelastpickle.tlpstress.converters
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+import kotlin.test.assertFailsWith
+
+internal class ValidTableNameConverterTest {
+
+    lateinit var converter: ValidTableNameConverter
+
+    @BeforeEach
+    fun setUp() {
+        converter = ValidTableNameConverter()
+    }
+
+    @Test
+    fun convert() {
+        assertThat(converter.convert("-test1")).isEqualTo("_test1")
+        assertThat(converter.convert("# -test ")).isEqualTo("___test_")
+        assertThat(converter.convert("-test-1-a")).isEqualTo("_test_1_a")
+    }
+}


### PR DESCRIPTION
**This PR should be merged only once #42 has been merged and the branch should be rebased on master first.**
Add the possibility to suffix the table names, to ease stressing a cluster on several tables at the same time.

The optional suffix is sanitized to avoid generating invalid CQL table names, and will be added to all statements.
The IStressProfile interface was updated accordingly along with all the existing profiles.