### PR TITLE
Add documentation of changing logback configs

### DIFF
--- a/conf/logback-error.xml
+++ b/conf/logback-error.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date %highlight(%-5level) [%thread] %highlight(%class.%method:%line) - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!--
+      <logger name="com.mycompany">
+          <level value="DEBUG" />
+      </logger>
+  -->
+
+  <root level="error">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>

--- a/docs/index.html
+++ b/docs/index.html
@@ -454,6 +454,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_getting_information_about_a_workload">Getting information about a workload</a></li>
 <li><a href="#_running_a_customized_stress_workload">Running a Customized Stress Workload</a></li>
 <li><a href="#_running_a_stress_test_for_a_given_duration_instead_of_a_number_of_operations">Running a stress test for a given duration instead of a number of operations</a></li>
+<li><a href="#_logging">Logging</a></li>
 </ul>
 </li>
 <li><a href="#_developer_docs">Developer Docs</a>
@@ -618,7 +619,7 @@ Usage: tlp-stress [options] [command] [command options]
           --concurrency, -c
             Concurrent queries allowed.  Increase for larger clusters.
             Default: 100
-          --coordinatorOnly, --co
+          --coordinatoronly, --co
             Coordinator only made.  This will cause tlp-stress to round robin
             between nodes without tokens.  Requires using -Djoin_ring=false in
             cassandra-env.sh.  When using this option you must only provide a
@@ -840,6 +841,42 @@ workload to specify which fields can be used this way.</p>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_logging">Logging</h3>
+<div class="paragraph">
+<p><code>tlp-stress</code> uses the <a href="https://logback.qos.ch/" target="_blank" rel="noopener">Logback</a> logging utility which is similar to <a href="https://en.wikipedia.org/wiki/Log4j" target="_blank" rel="noopener">log4j</a> <a href="https://logback.qos.ch/reasonsToSwitch.html" target="_blank" rel="noopener">(but better!)</a></p>
+</div>
+<div class="paragraph">
+<p>You can find to example logback configs in <a href="https://github.com/thelastpickle/tlp-stress/tree/master/conf" target="_blank" rel="noopener"><code>conf</code></a></p>
+</div>
+<div class="paragraph">
+<p>To use a different logging configuration, simply set the shell variable <code>TLP_STRESS_LOGBACK</code> to the path of the new logging configuration before running <code>tlp-stress</code></p>
+</div>
+<div class="sect3">
+<h4 id="_example">Example</h4>
+<div class="paragraph">
+<p>Let&#8217;s say you found the output to be overly verbose and only want the results and errors. You can easily change this by setting <code>level</code> to <code>error</code> a like so:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>&lt;root level="error"&gt;
+  &lt;appender-ref ref="STDOUT"/&gt;
+&lt;/root&gt;</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Read more about logback logging levels here: <a href="https://logback.qos.ch/manual/architecture.html#LoggerContext" class="bare">https://logback.qos.ch/manual/architecture.html#LoggerContext</a>)</p>
+</div>
+<div class="paragraph">
+<p>Assuming this repo is in your current working directory, you would set the logging config and run <code>tlp-stress</code> as follows:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>TLP_STRESS_LOGBACK=./conf/logback-error.xml tlp-stress run KeyValue</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -875,7 +912,7 @@ workload to specify which fields can be used this way.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-01-29 19:37:29 UTC
+Last updated 2019-02-21 23:49:15 UTC
 </div>
 </div>
 </body>

--- a/manual/MANUAL.adoc
+++ b/manual/MANUAL.adoc
@@ -161,6 +161,32 @@ There are other generators available, such as names, gaussian numbers,
 and cities. Not every generator applies to every type. It’s up to the
 workload to specify which fields can be used this way.
 
+=== Logging
+
+`tlp-stress` uses the https://logback.qos.ch/[Logback, window="_blank"] logging utility which is similar to https://en.wikipedia.org/wiki/Log4j[log4j, window="_blank"] https://logback.qos.ch/reasonsToSwitch.html[(but better!), window="_blank"]
+
+You can find to example logback configs in https://github.com/thelastpickle/tlp-stress/tree/master/conf[`conf`, window="_blank"]
+
+To use a different logging configuration, simply set the shell variable `TLP_STRESS_LOGBACK` to the path of the new logging configuration before running `tlp-stress`
+
+==== Example
+
+Let's say you found the output to be overly verbose and only want the results and any errors. You can easily change this by setting `level` attribute to `error` like so:
+
+```
+<root level="error">
+  <appender-ref ref="STDOUT"/>
+</root>
+```
+
+Read more about logback logging levels here: https://logback.qos.ch/manual/architecture.html#LoggerContext)
+
+Assuming this repo is in your current working directory, you can set the logging config and run `tlp-stress` as follows:
+
+```
+TLP_STRESS_LOGBACK=./conf/logback-error.xml tlp-stress run KeyValue
+```
+
 == Developer Docs
 
 === Building the documentation


### PR DESCRIPTION
This PR adds a "Logging" section to the documentation and describes how to use logback.

Includes an example of a "errors only" logback config and adds that to `conf`

Feedback or changes to this PR are welcome. This was just a thing we had to figure out when using the tool and felt it would be helpful for others.