### PR TITLE
Add a --csv flag and write metrics to csv files

### DIFF
--- a/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
@@ -17,9 +17,9 @@ class FileReporter(registry: MetricRegistry) : ScheduledReporter(registry,
 ) {
     private val startingTimestamp = Instant.now().toString()
     private val metricsDir = "metrics-$startingTimestamp"
-    private val readFilename = "$metricsDir/read-$startingTimestamp.csv"
-    private val writeFilename = "$metricsDir/write-$startingTimestamp.csv"
-    private val errorFilename = "$metricsDir/error-$startingTimestamp.csv"
+    private val readFilename = "$metricsDir/read.csv"
+    private val writeFilename = "$metricsDir/write.csv"
+    private val errorFilename = "$metricsDir/error.csv"
 
     private val opHeaders = listOf("Timestamp", "Count", "Latency (p99)", "1min (req/s)").joinToString(",")
     private val errorHeaders = listOf("Timestamp", "Count", "1min (errors/s)").joinToString(",")
@@ -60,7 +60,6 @@ class FileReporter(registry: MetricRegistry) : ScheduledReporter(registry,
                 .joinToString(",")
         writeToFile(errorFilename, errorRow)
     }
-
 
     fun writeToFile(filename: String, text: String) {
         FileWriter(filename, true).use { out ->

--- a/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
@@ -1,0 +1,70 @@
+package com.thelastpickle.tlpstress
+
+import com.codahale.metrics.*
+import com.codahale.metrics.Timer
+import java.io.File
+import java.io.FileWriter
+import java.text.DecimalFormat
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class FileReporter(registry: MetricRegistry) : ScheduledReporter(registry,
+        "file-reporter",
+        MetricFilter.ALL,
+        TimeUnit.SECONDS,
+        TimeUnit.MILLISECONDS
+) {
+    private val startingTimestamp = Instant.now().toString()
+    private val metricsDir = "metrics-$startingTimestamp"
+    private val readFilename = "$metricsDir/read-$startingTimestamp.csv"
+    private val writeFilename = "$metricsDir/write-$startingTimestamp.csv"
+    private val errorFilename = "$metricsDir/error-$startingTimestamp.csv"
+
+    private val opHeaders = listOf("Timestamp", "Count", "Latency (p99)", "1min (req/s)").joinToString(",")
+    private val errorHeaders = listOf("Timestamp", "Count", "1min (errors/s)").joinToString(",")
+
+    init {
+        File(metricsDir).mkdir()
+
+        writeToFile(readFilename, opHeaders)
+        writeToFile(writeFilename, opHeaders)
+        writeToFile(errorFilename, errorHeaders)
+    }
+
+    private fun Timer.getMetricsList(timestamp: String): List<Any> {
+        val duration = convertDuration(this.snapshot.get99thPercentile())
+        return listOf(timestamp, this.count, duration, this.oneMinuteRate)
+    }
+
+    override fun report(gauges: SortedMap<String, Gauge<Any>>?,
+                        counters: SortedMap<String, Counter>?,
+                        histograms: SortedMap<String, Histogram>?,
+                        meters: SortedMap<String, Meter>?,
+                        timers: SortedMap<String, Timer>?) {
+
+        val timestamp = Instant.now().toString()
+
+        val writeRow = timers!!["mutations"]!!
+                .getMetricsList(timestamp)
+                .joinToString(",")
+        writeToFile(writeFilename, writeRow)
+
+        val readRow = timers["selects"]!!
+                .getMetricsList(timestamp)
+                .joinToString(",")
+        writeToFile(readFilename, readRow)
+
+        val errors = meters!!["errors"]!!
+        val errorRow = listOf(timestamp, errors.count, errors.oneMinuteRate)
+                .joinToString(",")
+        writeToFile(errorFilename, errorRow)
+    }
+
+
+    fun writeToFile(filename: String, text: String) {
+        FileWriter(filename, true).use { out ->
+            out.write("$text\n")
+        }
+    }
+}

--- a/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
@@ -4,10 +4,10 @@ import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.ScheduledReporter
 import java.util.concurrent.TimeUnit
 
-class Metrics(metricRegistry: MetricRegistry, val reporter: ScheduledReporter) {
+class Metrics(metricRegistry: MetricRegistry, val reporters: List<ScheduledReporter>) {
 
     fun startReporting() {
-        reporter.start(3, TimeUnit.SECONDS)
+        reporters.forEach { it.start(3, TimeUnit.SECONDS) }
     }
 
     val errors = metricRegistry.meter("errors")

--- a/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
@@ -1,19 +1,17 @@
 package com.thelastpickle.tlpstress
 
 import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.ScheduledReporter
 import java.util.concurrent.TimeUnit
 
-class Metrics {
-    val metrics = MetricRegistry()
-
-    val reporter = SingleLineConsoleReporter(metrics)
+class Metrics(metricRegistry: MetricRegistry, val reporter: ScheduledReporter) {
 
     fun startReporting() {
         reporter.start(3, TimeUnit.SECONDS)
     }
 
-    val errors = metrics.meter("errors")
-    val mutations = metrics.timer("mutations")
-    val selects = metrics.timer("selects")
+    val errors = metricRegistry.meter("errors")
+    val mutations = metricRegistry.timer("mutations")
+    val selects = metricRegistry.timer("selects")
 
 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
@@ -115,14 +115,14 @@ class ProfileRunner(val context: StressContext,
                 is Operation.Mutation -> {
 //                    logger.debug { op }
 
-                    val startTimes = context.metricsList.map { it.mutations.time() }
+                    val startTime = context.metrics.mutations.time()
                     val future = context.session.executeAsync(op.bound)
 
                     Futures.addCallback(future, object : FutureCallback<ResultSet> {
                         override fun onFailure(t: Throwable?) {
                             sem.release()
-                            context.metricsList[0].errors.mark()
-                            startTimes.forEach { it.stop() }
+                            context.metrics.errors.mark()
+                            startTime.stop()
 
                         }
 
@@ -132,21 +132,20 @@ class ProfileRunner(val context: StressContext,
                             // if not, use the sampler frequency
                             // need to be mindful of memory, frequency is a stopgap
 //                            sampler.maybePut(op.partitionKey, op.fields)
-                            startTimes.forEach { it.stop() }
+                            startTime.stop()
                             runner.onSuccess(op, result)
-
                         }
                     })
                 }
 
                 is Operation.SelectStatement -> {
-                    val startTimes = context.metricsList.map { it.selects.time() }
+                    val startTime = context.metrics.selects.time()
                     val future = context.session.executeAsync(op.bound)
                     Futures.addCallback(future, object : FutureCallback<ResultSet> {
                         override fun onFailure(t: Throwable?) {
                             sem.release()
-                            context.metricsList[0].errors.mark()
-                            startTimes.forEach { it.stop() }
+                            context.metrics.errors.mark()
+                            startTime.stop()
                         }
 
                         override fun onSuccess(result: ResultSet?) {
@@ -154,8 +153,7 @@ class ProfileRunner(val context: StressContext,
                             // if the key returned in the Mutation exists in the sampler, store the fields
                             // if not, use the sampler frequency
                             // need to be mindful of memory, frequency is a stopgap
-                            startTimes.forEach { it.stop() }
-
+                            startTime.stop()
                         }
                     })
                 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
@@ -115,13 +115,13 @@ class ProfileRunner(val context: StressContext,
                 is Operation.Mutation -> {
 //                    logger.debug { op }
 
-                    val startTime = context.metrics.mutations.time()
+                    val startTime = context.metricsList[0].mutations.time()
                     val future = context.session.executeAsync(op.bound)
 
                     Futures.addCallback(future, object : FutureCallback<ResultSet> {
                         override fun onFailure(t: Throwable?) {
                             sem.release()
-                            context.metrics.errors.mark()
+                            context.metricsList.map { it.errors.mark() }
                             startTime.stop()
 
 
@@ -141,12 +141,12 @@ class ProfileRunner(val context: StressContext,
                 }
 
                 is Operation.SelectStatement -> {
-                    val startTime = context.metrics.selects.time()
+                    val startTime = context.metricsList[0].selects.time()
                     val future = context.session.executeAsync(op.bound)
                     Futures.addCallback(future, object : FutureCallback<ResultSet> {
                         override fun onFailure(t: Throwable?) {
                             sem.release()
-                            context.metrics.errors.mark()
+                            context.metricsList.map { it.errors.mark() }
                             startTime.stop()
                         }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.Semaphore
 data class StressContext(val session: Session,
                          val mainArguments: Run,
                          val thread: Int,
-                         val metrics: Metrics,
+                         val metricsList: List<Metrics>,
                          val permits: Int,
                          val registry: Registry,
                          val rateLimiter: RateLimiter?)

--- a/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/StressContext.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.Semaphore
 data class StressContext(val session: Session,
                          val mainArguments: Run,
                          val thread: Int,
-                         val metricsList: List<Metrics>,
+                         val metrics: Metrics,
                          val permits: Int,
                          val registry: Registry,
                          val rateLimiter: RateLimiter?)

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -241,7 +241,7 @@ class Run : IStressCommand {
 
         println("$executed threads prepared.")
 
-        metricsList.map { it.startReporting() }
+        metricsList.forEach { it.startReporting() }
 
         val runnersExecuted = runners.parallelStream().map {
             println("Running")
@@ -254,7 +254,7 @@ class Run : IStressCommand {
         Thread.sleep(1000)
 
         // dump out metrics
-        metricsList.map { it.reporter.report() }
+        metricsList.forEach { it.reporter.report() }
     }
 
 }


### PR DESCRIPTION
This adds a flag `--csv`.  When you run with this flag set:
- Metrics do not get written to the console with SingleLineConsoleReporter
- Create a directory called `metrics-[timestamp]`
- Write the metrics for reads, writes and errors to `read-[timestamp].csv`, `write-[timestamp].csv` and `error-[timestamp].csv` respectively.