### PR TITLE
The default Prometheus port seems to be 9500

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -866,7 +866,7 @@ workload to specify which fields can be used this way.</p>
 <div class="sect2">
 <h3 id="_exporting_metrics">Exporting Metrics</h3>
 <div class="paragraph">
-<p>tlp-stress automatically runs an HTTP server exporting metrics in Prometheus format on port 9501.</p>
+<p>tlp-stress automatically runs an HTTP server exporting metrics in Prometheus format on port 9500.</p>
 </div>
 </div>
 </div>

--- a/manual/MANUAL.adoc
+++ b/manual/MANUAL.adoc
@@ -179,7 +179,7 @@ The Debian package installs a basic configuration file to `/etc/tlp-stress/log4j
 
 === Exporting Metrics
 
-tlp-stress automatically runs an HTTP server exporting metrics in Prometheus format on port 9501.
+tlp-stress automatically runs an HTTP server exporting metrics in Prometheus format on port 9500.
 
 
 == Developer Docs


### PR DESCRIPTION
93edf83c5b7e2a722de7d42da4c214a21aad9722 changed the default Prometheus port to 9501, and af77e49d947fc948815d6a18fd407ba1d3fef34e updated the docs to reflect this. But 00b53af5c86199fece8cea6a3eea4d31fa7e7b81 changed the default back to 9500.