### PR TITLE
make the native transport port configurable

### DIFF
--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -39,7 +39,7 @@ class Run : IStressCommand {
     @Parameter(names = ["--host"])
     var host = "127.0.0.1"
 
-    @Parameter(names = ["--cqlport"], description = "Override the cql port. Defaults to 9042.")
+    @Parameter(names = ["--port"], description = "Override the cql port. Defaults to 9042.")
     var cqlPort = 9042
 
     @Parameter(names = ["--username", "-U"])

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -39,6 +39,9 @@ class Run : IStressCommand {
     @Parameter(names = ["--host"])
     var host = "127.0.0.1"
 
+    @Parameter(names = ["--cqlport"], description = "Override the cql port. Defaults to 9042.")
+    var cqlPort = 9042
+
     @Parameter(names = ["--username", "-U"])
     var username = "cassandra"
 
@@ -159,6 +162,7 @@ class Run : IStressCommand {
 
         var builder = Cluster.builder()
                 .addContactPoint(host)
+                .withPort(cqlPort)
                 .withCredentials(username, password)
                 .withQueryOptions(options)
                 .withPoolingOptions(PoolingOptions()


### PR DESCRIPTION
I named the option `cqlport` as opposed to `cql-port` to be consistent with naming, e.g., `prometheusport`. I also chose `cqlport` because `nativetransportport` is way too verbose IMO.