### PR TITLE
Add the ability to generate tombstones in stress workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tlp-stress: A workload centric stress tool and framework
 
+[![CircleCI](https://circleci.com/gh/thelastpickle/tlp-stress.svg?style=svg)](https://circleci.com/gh/thelastpickle/tlp-stress)
+
 This project is a work in progress. 
 
 Please see our [Google Group](https://groups.google.com/d/forum/tlp-dev-tools) for discussion.

--- a/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/FileReporter.kt
@@ -41,10 +41,12 @@ class FileReporter(registry: MetricRegistry, outputFileName: String, command: St
 
         buffer.write(",,Mutations,,,")
         buffer.write("Reads,,,")
+        buffer.write("Deletes,,,")
         buffer.write("Errors,")
         buffer.newLine()
 
         buffer.write("Timestamp, Elapsed Time,")
+        buffer.write(opHeaders)
         buffer.write(opHeaders)
         buffer.write(opHeaders)
         buffer.write(errorHeaders)
@@ -79,6 +81,12 @@ class FileReporter(registry: MetricRegistry, outputFileName: String, command: St
                 .joinToString(",", postfix = ",")
 
         buffer.write(readRow)
+
+        val deleteRow = timers["deletions"]!!
+                .getMetricsList()
+                .joinToString(",", postfix = ",")
+
+        buffer.write(deleteRow)
 
         val errors = meters!!["errors"]!!
         val errorRow = listOf(errors.count, errors.oneMinuteRate)

--- a/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/Metrics.kt
@@ -36,6 +36,7 @@ class Metrics(metricRegistry: MetricRegistry, val reporters: List<ScheduledRepor
     val errors = metricRegistry.meter("errors")
     val mutations = metricRegistry.timer("mutations")
     val selects = metricRegistry.timer("selects")
+    val deletions = metricRegistry.timer("deletions")
 
     val populate = metricRegistry.timer("populateMutations")
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/ProfileRunner.kt
@@ -70,19 +70,6 @@ class ProfileRunner(val context: StressContext,
         }
     }
 
-    val rangeDeleteRate: Double
-
-    init {
-        val tmp = context.mainArguments.rangeDeleteRate
-
-        if(tmp != null) {
-            rangeDeleteRate = tmp
-        }
-        else {
-            rangeDeleteRate = profile.getDefaultReadRate()
-        }
-    }
-
     fun print(message: String) {
         println("[Thread ${context.thread}]: $message")
 
@@ -127,15 +114,13 @@ class ProfileRunner(val context: StressContext,
             // others can be randomly injected by the runner
             // I should be able to just tell the runner to inject gossip failures in any test
             // without having to write that code in the profile
-
-            val op : Operation = if(readRate * 100 > ThreadLocalRandom.current().nextInt(0, 100)) {
+            val nextOp = ThreadLocalRandom.current().nextInt(0, 100)
+            val op : Operation = if(readRate * 100 > nextOp) {
                 runner.getNextSelect(key)
+            } else if((readRate * 100) + (deleteRate * 100) > nextOp) {
+                runner.getNextDelete(key)
             } else {
-                if(deleteRate * 100 > ThreadLocalRandom.current().nextInt(0, 100)) {
-                    runner.getNextDelete(key)
-                } else {
-                    runner.getNextMutation(key)
-                }
+                runner.getNextMutation(key)
             }
             
             // if we're using the rate limiter (unlikely) grab a permit

--- a/src/main/kotlin/com/thelastpickle/tlpstress/SingleLineConsoleReporter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/SingleLineConsoleReporter.kt
@@ -51,7 +51,7 @@ class SingleLineConsoleReporter(registry: MetricRegistry) : ScheduledReporter(re
         val state = AtomicInteger()
 
         // this is a little weird, but we should show the same headers for writes & selects
-        val queries = listOf(timers!!["mutations"]!!, timers["selects"]!!)
+        val queries = listOf(timers!!["mutations"]!!, timers["selects"]!!, timers["deletions"]!!)
 
         for(queryType in queries) {
             with(queryType) {
@@ -115,13 +115,15 @@ class SingleLineConsoleReporter(registry: MetricRegistry) : ScheduledReporter(re
         print(" ".repeat(paddingEachSide))
         print(termColors.blue("Reads"))
         print(" ".repeat(paddingEachSide))
-
+        print(termColors.blue("Deletes"))
+        print(" ".repeat(paddingEachSide))
+        print(" ".repeat(paddingEachSide))
         print(termColors.red("Errors"))
 
         println()
         var i = 0
 
-        for(x in 0..1) {
+        for(x in 0..2) {
 
             for (h in opHeaders) {
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -147,10 +147,7 @@ class Run(val command: String) : IStressCommand {
 
     @Parameter(names = ["--deleterate", "--deletes"], description = "Deletion Rate, 0-1.  Workloads may have their own defaults.  Default is dependent on workload.")
     var deleteRate : Double? = null
-
-    @Parameter(names = ["--rangedeleterate", "--rangedeletes"], description = "Range Deletion Rate, 0-1.  Workloads may have their own defaults.  Default is dependent on workload.")
-    var rangeDeleteRate : Double? = null
-
+    
     val log = logger()
 
     /**

--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -145,6 +145,11 @@ class Run(val command: String) : IStressCommand {
     @Parameter(names = ["--no-schema"], description = "Skips schema creation")
     var noSchema: Boolean = false
 
+    @Parameter(names = ["--deleterate", "--deletes"], description = "Deletion Rate, 0-1.  Workloads may have their own defaults.  Default is dependent on workload.")
+    var deleteRate : Double? = null
+
+    @Parameter(names = ["--rangedeleterate", "--rangedeletes"], description = "Range Deletion Rate, 0-1.  Workloads may have their own defaults.  Default is dependent on workload.")
+    var rangeDeleteRate : Double? = null
 
     val log = logger()
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/AllowFiltering.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/AllowFiltering.kt
@@ -59,6 +59,9 @@ class AllowFiltering : IStressProfile {
                 return Operation.SelectStatement(bound)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/AllowFiltering.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/AllowFiltering.kt
@@ -21,10 +21,12 @@ class AllowFiltering : IStressProfile {
 
     lateinit var insert : PreparedStatement
     lateinit var select: PreparedStatement
+    lateinit var delete: PreparedStatement
 
     override fun prepare(session: Session) {
         insert = session.prepare("INSERT INTO allow_filtering (partition_id, row_id, value, payload) values (?, ?, ?, ?)")
         select = session.prepare("SELECT * from allow_filtering WHERE partition_id = ? and value = ? ALLOW FILTERING")
+        delete = session.prepare("DELETE from allow_filtering WHERE partition_id = ? and row_id = ?")
     }
 
     override fun schema(): List<String> {
@@ -60,7 +62,9 @@ class AllowFiltering : IStressProfile {
             }
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
-                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+                val rowId = random.nextInt(0, rows)
+                val bound = delete.bind(partitionKey.getText(), rowId)
+                return Operation.Deletion(bound)
             }
         }
     }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/BasicTimeSeries.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/BasicTimeSeries.kt
@@ -63,6 +63,9 @@ class BasicTimeSeries : IStressProfile {
                 return Operation.Mutation(bound)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/CountersWide.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/CountersWide.kt
@@ -61,6 +61,9 @@ class CountersWide : IStressProfile {
                 return Operation.SelectStatement(selectAll.bind(partitionKey.getText()))
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/IStressProfile.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/IStressProfile.kt
@@ -13,6 +13,7 @@ import com.thelastpickle.tlpstress.generators.Field
 interface IStressRunner {
     fun getNextMutation(partitionKey: PartitionKey) : Operation
     fun getNextSelect(partitionKey: PartitionKey) : Operation
+    fun getNextDelete(partitionKey: PartitionKey) : Operation
     /**
      * Callback after a query executes successfully.
      * Will be used for state tracking on things like LWTs as well as provides an avenue for future work
@@ -95,6 +96,8 @@ sealed class Operation(val bound: BoundStatement) {
     class Mutation(bound: BoundStatement, val callbackPayload: Any? = null ) : Operation(bound)
 
     class SelectStatement(bound: BoundStatement): Operation(bound)
+
+    class Deletion(bound: BoundStatement): Operation(bound)
 
 
 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/KeyValue.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/KeyValue.kt
@@ -14,11 +14,13 @@ class KeyValue : IStressProfile {
 
     lateinit var insert: PreparedStatement
     lateinit var select: PreparedStatement
+    lateinit var delete: PreparedStatement
 
 
     override fun prepare(session: Session) {
         insert = session.prepare("INSERT INTO keyvalue (key, value) VALUES (?, ?)")
         select = session.prepare("SELECT * from keyvalue WHERE key = ?")
+        delete = session.prepare("DELETE from keyvalue WHERE key = ?")
     }
 
     override fun schema(): List<String> {
@@ -51,6 +53,10 @@ class KeyValue : IStressProfile {
                 return Operation.Mutation(bound)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                val bound = delete.bind(partitionKey.getText())
+                return Operation.Deletion(bound)
+            }
         }
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/LWT.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/LWT.kt
@@ -49,6 +49,10 @@ class LWT : IStressProfile {
 
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
+
             override fun onSuccess(op: Operation.Mutation, result: ResultSet?) {
                 val payload = op.callbackPayload!! as CallbackPayload
                 state[payload.id] = payload.value

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/LWT.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/LWT.kt
@@ -11,6 +11,8 @@ class LWT : IStressProfile {
     lateinit var insert : PreparedStatement
     lateinit var update: PreparedStatement
     lateinit var select: PreparedStatement
+    lateinit var delete: PreparedStatement
+    lateinit var deletePartition: PreparedStatement
 
     override fun schema(): List<String> {
         return arrayListOf("""CREATE TABLE IF NOT EXISTS lwt (id text primary key, value int) """)
@@ -20,6 +22,8 @@ class LWT : IStressProfile {
         insert = session.prepare("INSERT INTO lwt (id, value) VALUES (?, ?) IF NOT EXISTS")
         update = session.prepare("UPDATE lwt SET value = ? WHERE id = ? IF value = ?")
         select = session.prepare("SELECT * from lwt WHERE id = ?")
+        delete = session.prepare("DELETE from lwt WHERE id = ? IF value = ?")
+        deletePartition = session.prepare("DELETE from lwt WHERE id = ? IF EXISTS")
     }
 
 
@@ -46,11 +50,18 @@ class LWT : IStressProfile {
 
             override fun getNextSelect(partitionKey: PartitionKey): Operation {
                 return Operation.SelectStatement(select.bind(partitionKey.getText()))
-
             }
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
-                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+                val currentValue = state[partitionKey.getText()]
+                val newValue: Int
+
+                val deletion = if(currentValue != null) {
+                    delete.bind(partitionKey.getText(), currentValue)
+                } else {
+                    deletePartition.bind(partitionKey.getText())
+                }
+                return Operation.Deletion(deletion)
             }
 
             override fun onSuccess(op: Operation.Mutation, result: ResultSet?) {

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Locking.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Locking.kt
@@ -79,6 +79,10 @@ class Locking : IStressProfile {
                 return Operation.SelectStatement(bound)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
+
             override fun customPopulateIter() = iterator {
 
                 val generator = ProfileRunner.getGenerator(context, "sequence")

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Locking.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Locking.kt
@@ -30,6 +30,7 @@ class Locking : IStressProfile {
     lateinit var insert: PreparedStatement
     lateinit var update: PreparedStatement
     lateinit var select: PreparedStatement
+    lateinit var delete: PreparedStatement
 
     var log = logger()
 
@@ -37,6 +38,7 @@ class Locking : IStressProfile {
         insert = session.prepare("INSERT INTO lwtupdates (item_id, name, status) VALUES (?, ?, 0)")
         update = session.prepare("UPDATE lwtupdates set status = ? WHERE item_id = ? IF status = ?")
         select = session.prepare("SELECT * from lwtupdates where item_id = ?")
+        delete = session.prepare("DELETE from lwtupdates where item_id = ?")
     }
 
     override fun schema(): List<String> {
@@ -80,7 +82,8 @@ class Locking : IStressProfile {
             }
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
-                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+                val bound = delete.bind(partitionKey.getText())
+                return Operation.Deletion(bound)
             }
 
             override fun customPopulateIter() = iterator {

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Maps.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Maps.kt
@@ -37,6 +37,9 @@ class Maps : IStressProfile {
                 return Operation.Mutation(b)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Maps.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/Maps.kt
@@ -14,10 +14,12 @@ class Maps : IStressProfile {
 
     lateinit var insert : PreparedStatement
     lateinit var select : PreparedStatement
+    lateinit var delete : PreparedStatement
 
     override fun prepare(session: Session) {
         insert = session.prepare("UPDATE map_stress SET data[?] = ? WHERE id = ?")
         select = session.prepare("SELECT * from map_stress WHERE id = ?")
+        delete = session.prepare("DELETE from map_stress WHERE id = ?")
     }
 
     override fun schema(): List<String> {
@@ -29,16 +31,17 @@ class Maps : IStressProfile {
     override fun getRunner(context: StressContext): IStressRunner {
         return object : IStressRunner {
             override fun getNextMutation(partitionKey: PartitionKey): Operation {
-                return Operation.SelectStatement(insert.bind("key", "value", partitionKey.getText()))
+                return Operation.Mutation(insert.bind("key", "value", partitionKey.getText()))
             }
 
             override fun getNextSelect(partitionKey: PartitionKey): Operation {
                 val b = select.bind(partitionKey.getText())
-                return Operation.Mutation(b)
+                return Operation.SelectStatement(b)
             }
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
-                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+                val b = delete.bind(partitionKey.getText())
+                return Operation.Deletion(b)
             }
         }
     }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/MaterializedViews.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/MaterializedViews.kt
@@ -17,6 +17,7 @@ class MaterializedViews : IStressProfile {
         select_base = session.prepare("SELECT * FROM person WHERE name = ?")
         select_by_age = session.prepare("SELECT * FROM person_by_age WHERE age = ?")
         select_by_city = session.prepare("SELECT * FROM person_by_city WHERE city = ?")
+        delete_base = session.prepare("DELETE FROM person WHERE name = ?")
 
 
     }
@@ -60,7 +61,7 @@ class MaterializedViews : IStressProfile {
             }
 
             override fun getNextDelete(partitionKey: PartitionKey): Operation {
-                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+                return Operation.Deletion(delete_base.bind(partitionKey.getText()))
             }
         }
     }
@@ -78,4 +79,5 @@ class MaterializedViews : IStressProfile {
     lateinit var select_base : PreparedStatement
     lateinit var select_by_age : PreparedStatement
     lateinit var select_by_city : PreparedStatement
+    lateinit var delete_base : PreparedStatement
 }

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/MaterializedViews.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/MaterializedViews.kt
@@ -59,6 +59,9 @@ class MaterializedViews : IStressProfile {
                 return result
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/RandomPartitionAccess.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/RandomPartitionAccess.kt
@@ -83,6 +83,9 @@ class RandomPartitionAccess : IStressProfile {
 
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/RandomPartitionAccess.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/RandomPartitionAccess.kt
@@ -16,7 +16,7 @@ class RandomPartitionAccess : IStressProfile {
     @WorkloadParameter(description = "Number of rows per partition, defaults to 100")
     var rows = 100
 
-    @WorkloadParameter("Select random row or the entire partition.  Acceptable values: row, partition")
+    @WorkloadParameter("Select and delete random row or the entire partition.  Acceptable values: row, partition")
     var select = "row"
 
     lateinit var insert : PreparedStatement

--- a/src/main/kotlin/com/thelastpickle/tlpstress/profiles/UdtTimeSeries.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/profiles/UdtTimeSeries.kt
@@ -72,6 +72,9 @@ class UdtTimeSeries : IStressProfile {
                 return Operation.Mutation(bound)
             }
 
+            override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                throw UnsupportedOperationException("Deletions are not implemented for this workload")
+            }
         }
     }
 

--- a/src/test/kotlin/com/thelastpickle/tlpstress/PluginTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpstress/PluginTest.kt
@@ -46,6 +46,11 @@ internal class PluginTest {
                     val b = mockk<BoundStatement>()
                     return Operation.SelectStatement(b)
                 }
+
+                override fun getNextDelete(partitionKey: PartitionKey): Operation {
+                    val b = mockk<BoundStatement>()
+                    return Operation.Deletion(b)
+                }
             }
         }
 


### PR DESCRIPTION
First iteration on that feature.
I think range deletes should be a subset of the deletes: the ratio of range deletes will be based on deletes, not mutations. 
This means putting `--rangedeletes 0.5` will make half of the deletes be range deletes, but the ratio of deletes is still computed according to the mutations. To give a full example (I don't feel I'm being clear enough) :  `--rangedeletes 0.5 --deletes 0.1` will generate 10% of deletes of which 50% will be range deletes (ie: deletion of multiple rows).
I'm also reporting deletes separately, although they are really mutations, but it's better to see how many of those are generated.

@rustyrazorblade, let me know if this matches your requirements and I'll move forward with the other workloads (only the KV one is implemented for now).
