### PR TITLE
Modify wrapper script to not bash-parse quotes in cli args

### DIFF
--- a/bin/tlp-stress
+++ b/bin/tlp-stress
@@ -6,7 +6,7 @@ cd $BASE_STRESS_DIR
 
 JAR=$(find build/libs -name '*-all.jar' | tail -n 1)
 
-java -jar $JAR $@
+java -jar $JAR "$@"
 
 
 


### PR DESCRIPTION
Ran into exceptions running cli commands, getting errors like the following (using one of the examples in the README)

```
[kysamson@kysamson-dev tlp-stress]$ ./bin/tlp-stress run BasicTimeSeries -i 10M --compaction "{'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 1, 'compaction_window_unit': 'DAYS'}"
Exception in thread "main" com.beust.jcommander.ParameterException: Only one main parameter allowed but found several: "BasicTimeSeries" and "'compaction_window_size':"
	at com.beust.jcommander.JCommander$MainParameter.addValue(JCommander.java:97)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:773)
	at com.beust.jcommander.JCommander.parse(JCommander.java:340)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:787)
	at com.beust.jcommander.JCommander.parse(JCommander.java:340)
	at com.beust.jcommander.JCommander.parse(JCommander.java:319)
	at com.thelastpickle.tlpstress.CommandLineParser$Companion.parse(CommandLineParser.kt:40)
	at com.thelastpickle.tlpstress.MainKt.main(Main.kt:11)
```

Adding quotes around the `$@` in the wrapper script allow it to parse correctly. Only tested that script from a bash shell as I do not know the usual method it's run.