### PR TITLE
Pushing Log4J to 2.16 due to security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,13 @@ dependencies {
     // https://mvnrepository.com/artifact/org.reflections/reflections
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
 
-    compile group: "org.apache.logging.log4j", name: "log4j-api", version: "2.12.1"
-    compile group: "org.apache.logging.log4j", name: "log4j-core", version:"2.12.1"
+    compile group: "org.apache.logging.log4j", name: "log4j-api", version: "2.16.0"
+    compile group: "org.apache.logging.log4j", name: "log4j-core", version:"2.16.0"
     compile "org.apache.logging.log4j:log4j-api-kotlin:1.0.0"
     // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j18-impl
     // maps the datastax driver slf4j calls to log4j
 
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.11.2'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
 
     // needed for yaml logging configurations
 


### PR DESCRIPTION
Attempting to patch the Log4J vulnerability. I'm not a well-versed developer, but build was passing locally with just these changes so I decided to open the MR. I was seeing some test failures around not being able to connect to 127.0.0.1, but I figured I was just missing some step where I needed to start a process before running those tests (didn't see docs around that either in my quick glance through). 

Anyway, hopefully, this works as intended. 