### PR TITLE
Fix for Java 17: Replace incorrect usages of map with forEach

### DIFF
--- a/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpstress/commands/Run.kt
@@ -22,8 +22,6 @@ import com.thelastpickle.tlpstress.generators.Registry
 import me.tongfei.progressbar.ProgressBar
 import me.tongfei.progressbar.ProgressBarStyle
 import org.apache.logging.log4j.kotlin.logger
-import java.io.File
-import java.lang.RuntimeException
 import kotlin.concurrent.fixedRateTimer
 
 class NoSplitter : IParameterSplitter {
@@ -264,7 +262,7 @@ class Run(val command: String) : IStressCommand {
 
         // Both of the following are set in the try block, so this is OK
         val metrics = createMetrics()
-        var runnersExecuted = 0L
+        var runnersExecuted = 0
 
         try {
             // run the prepare for each
@@ -276,10 +274,12 @@ class Run(val command: String) : IStressCommand {
 
             metrics.startReporting()
 
-            runnersExecuted = runners.parallelStream().map {
+            runnersExecuted = runners.size
+
+            runners.parallelStream().forEach {
                 println("Running")
                 it.run()
-            }.count()
+            }
 
             Thread.sleep(1000)
 
@@ -324,9 +324,9 @@ class Run(val command: String) : IStressCommand {
                 }
 
                 // calling it on the runner
-                runners.parallelStream().map {
+                runners.parallelStream().forEach {
                     it.populate(populate)
-                }.count()
+                }
 
                 // have we really reached 100%?
                 Thread.sleep(1000)
@@ -347,12 +347,12 @@ class Run(val command: String) : IStressCommand {
             ProfileRunner.create(context, plugin.instance)
         }
 
-        val executed = runners.parallelStream().map {
+       runners.parallelStream().forEach {
             println("Preparing statements.")
             it.prepare()
-        }.count()
+        }
 
-        println("$executed threads prepared.")
+        println("${runners.size} threads prepared.")
         return runners
     }
 


### PR DESCRIPTION
This PR replaces all instances of `parallelStream().map{...}.count()` with `parallelStream().forEach{...}`.

The API of Java streams allows for the `count()` operation to short circuit and not execute the preceding `map()` functions if the JVM if it is capable of computing the count directly from the stream source. [Docs here](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#count())

Without this change, I was unable to get tlp-stress to work on my cluster. No errors were emitted, but no runners were actually getting executed.  I experienced this issue when compiling with Corretto OpenJDK 11.0.20.1 and running with Corretto OpenJDK 17.0.9